### PR TITLE
Make dependency compileOnly

### DIFF
--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -29,7 +29,8 @@ repositories {
 }
 
 dependencies {
-    compile 'org.jetbrains:annotations:13.0'
+    compileOnly 'org.jetbrains:annotations:13.0'
+    testCompileOnly 'org.jetbrains:annotations:13.0'
     testCompile 'org.assertj:assertj-core:2.6.0'
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Make the `org.jetbrains:annotations` dependency compileOnly so it will not be included in the final jar as it is not needed. according to http://www.methodscount.com/?lib=com.twitter.serial%3Aserial%3A0.1.5 it will save 24 methods and 8kb on the final dex. yay! 🎉 