### PR TITLE
Fix bug decoding UTF-8

### DIFF
--- a/serialization/src/main/java/com/twitter/serial/stream/bytebuffer/ByteBufferSerial.java
+++ b/serialization/src/main/java/com/twitter/serial/stream/bytebuffer/ByteBufferSerial.java
@@ -16,12 +16,14 @@
 
 package com.twitter.serial.stream.bytebuffer;
 
+import com.twitter.serial.serializer.SerializationContext;
+import com.twitter.serial.serializer.Serializer;
 import com.twitter.serial.stream.Serial;
 import com.twitter.serial.stream.SerializerInput;
 import com.twitter.serial.util.InternalSerialUtils;
 import com.twitter.serial.util.Pools;
-import com.twitter.serial.serializer.SerializationContext;
-import com.twitter.serial.serializer.Serializer;
+import com.twitter.serial.util.SerializationException;
+import com.twitter.serial.util.SerializationUtils;
 
 import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
@@ -106,7 +108,8 @@ public class ByteBufferSerial implements Serial {
         try {
             return serializer.deserialize(mContext, serializerInput);
         } catch (IOException | ClassNotFoundException | IllegalStateException e) {
-            throw e;
+            throw new SerializationException("Invalid serialized data:\n" +
+                    SerializationUtils.dumpSerializedData(bytes, serializerInput.getPosition(), mContext.isDebug()), e);
         }
     }
 

--- a/serialization/src/main/java/com/twitter/serial/stream/bytebuffer/ByteBufferSerializerInput.java
+++ b/serialization/src/main/java/com/twitter/serial/stream/bytebuffer/ByteBufferSerializerInput.java
@@ -267,7 +267,7 @@ public class ByteBufferSerializerInput extends SerializerInput {
             final StringBuilder builder = new StringBuilder(length);
             for (int i = 0; i < length; ++i) {
                 final int b1 = buffer.get();
-                if ((b1 & 0x80) >= 0) {
+                if ((b1 & 0x80) == 0) {
                     builder.append((char) b1);
                 } else if ((b1 & 0xE0) == 0xC0) {
                     final int b2 = buffer.get();

--- a/serialization/src/test/java/com/twitter/serial/stream/bytebuffer/ByteBufferSerializationTests.java
+++ b/serialization/src/test/java/com/twitter/serial/stream/bytebuffer/ByteBufferSerializationTests.java
@@ -149,7 +149,6 @@ public class ByteBufferSerializationTests {
     }
 
     @Test
-    @Ignore
     public void testSerializeString() throws Exception {
         final ByteBufferSerializerOutput output = new ByteBufferSerializerOutput();
         final String testString1 = "this is a test";


### PR DESCRIPTION
My last update to the utf-8 decoding code contained a bug that wasn't
caught by unit tests because the string parsing test was accidentally
disable. This patch fixes the bug, re-enables the test, and adds a
debugging helper that will make this kind of issue trivial to find.

Fixes #31 