### PR TITLE
Reduce visibility of mVersionNumber

### DIFF
--- a/serialization/src/main/java/com/twitter/serial/serializer/ObjectSerializer.java
+++ b/serialization/src/main/java/com/twitter/serial/serializer/ObjectSerializer.java
@@ -42,7 +42,7 @@ public abstract class ObjectSerializer<T> extends Serializer<T> {
     public static final byte NULL_OBJECT = 0;
     public static final byte NOT_NULL_OBJECT = 1;
 
-    protected final int mVersionNumber;
+    final int mVersionNumber;
 
     protected ObjectSerializer() {
         mVersionNumber = DEFAULT_VERSION;


### PR DESCRIPTION
There's not really any reason why this needs to be exposed and could potentially be the cause of bugs.